### PR TITLE
Add SREG2 to nftables bitwise attrs

### DIFF
--- a/netlink-bindings/src/nftables/nftables.yaml
+++ b/netlink-bindings/src/nftables/nftables.yaml
@@ -1003,6 +1003,7 @@ attribute-sets:
         type: nest
         nested-attributes: hook-dev-attrs
   -
+    # Defined in include/uapi/linux/netfilter/nf_tables.h
     name: expr-bitwise-attrs
     attributes:
       -
@@ -1036,6 +1037,10 @@ attribute-sets:
         name: data
         type: nest
         nested-attributes: data-attrs
+      -
+        name: sreg2
+        type: u32
+        byte-order: big-endian
   -
     name: expr-cmp-attrs
     attributes:


### PR DESCRIPTION
It's defined in the source code: [nf_tables.h](https://elixir.bootlin.com/linux/v6.17.4/source/include/uapi/linux/netfilter/nf_tables.h#L627)

For some reason it is missing from the documentation: [nftables.yaml](https://elixir.bootlin.com/linux/v6.17.4/source/Documentation/netlink/specs/nftables.yaml#L796-L799) (maybe forgotten when [bitwise ops](https://github.com/torvalds/linux/commit/b0ccf4f53d968e794a4ea579d5135cc1aaf1a53f) were added?)

However it use used by [nft tool](https://git.netfilter.org/nftables/tree/include/linux/netfilter/nf_tables.h?id=95482c8c809922aa870099e81c65568330b35b42#n617), so I believe it's safe to use :)