### PR TITLE
Define set-elem-flags enum

### DIFF
--- a/netlink-bindings/src/nftables/nftables.yaml
+++ b/netlink-bindings/src/nftables/nftables.yaml
@@ -146,6 +146,13 @@ definitions:
       - concat
       - expr
   -
+    # Defined in include/uapi/linux/netfilter/nf_tables.h as nft_set_elem_flags 
+    name: set-elem-flags
+    type: flags
+    entries:
+      - interval-end
+      - catchall
+  -
     name: lookup-flags
     type: flags
     entries:
@@ -828,7 +835,9 @@ attribute-sets:
         doc: data value of mapping
       -
         name: flags
-        type: binary
+        type: u32
+        enum: set-elem-flags
+        byte-order: big-endian
         doc: bitmask of nft_set_elem_flags
       -
         name: timeout


### PR DESCRIPTION
Some sources of the information I use:
- Enum `nft_set_elem_flags` is defined in [nf_tables.h](https://elixir.bootlin.com/linux/v6.17.5/source/include/uapi/linux/netfilter/nf_tables.h#L426-L435)
- Attribute `NFTA_SET_ELEM_FLAGS` is defined as u32: [nf_tables_api.c](https://elixir.bootlin.com/linux/v6.17.5/source/net/netfilter/nf_tables_api.c#L5987)
- and it's also big-endian: [nf_tables_api.c](https://elixir.bootlin.com/linux/v6.17.5/source/net/netfilter/nf_tables_api.c#L6370)