### PR TITLE
fix(multicast): fix compilation and compatibility for musl targets

### DIFF
--- a/netlink-socket/src/multicast.rs
+++ b/netlink-socket/src/multicast.rs
@@ -148,15 +148,17 @@ impl MulticastSocketRaw {
 
             let mut control_buf = [0u8; 128];
 
-            let mut msghdr = libc::msghdr {
-                msg_name: &mut addr as *mut libc::sockaddr_nl as *mut libc::c_void,
-                msg_namelen: std::mem::size_of_val(&addr) as u32,
-                msg_iov: &mut iov as *mut libc::iovec,
-                msg_iovlen: 1,
-                msg_control: control_buf.as_mut_ptr() as *mut libc::c_void,
-                msg_controllen: control_buf.len(),
-                msg_flags: 0,
-            };
+            // Use zeroed init + field assignment to avoid private-field struct
+            // literal restrictions on musl targets (__pad1, __pad2 in msghdr).
+            let mut msghdr: libc::msghdr = unsafe { std::mem::zeroed() };
+            msghdr.msg_name = &mut addr as *mut libc::sockaddr_nl as *mut libc::c_void;
+            msghdr.msg_namelen = std::mem::size_of_val(&addr) as u32;
+            msghdr.msg_iov = &mut iov as *mut libc::iovec;
+            msghdr.msg_iovlen = 1;
+            msghdr.msg_control = control_buf.as_mut_ptr() as *mut libc::c_void;
+            // msg_controllen is usize on glibc but u32 on musl - let the compiler infer.
+            msghdr.msg_controllen = control_buf.len() as _;
+            msghdr.msg_flags = 0;
 
             let read = unsafe { libc::recvmsg(sock.as_raw_fd(), &mut msghdr, 0) };
             if read < 0 {
@@ -177,13 +179,14 @@ impl MulticastSocketRaw {
                         cmsg_len,
                         cmsg_level,
                         cmsg_type,
+                        .. // ignore __pad1 on musl
                     } = *cmsg_ptr;
 
                     match (cmsg_level, cmsg_type) {
                         (libc::SOL_NETLINK, libc::NETLINK_PKTINFO) => {
                             let data = std::slice::from_raw_parts(
                                 libc::CMSG_DATA(cmsg_ptr),
-                                cmsg_len - libc::CMSG_LEN(0) as usize,
+                                cmsg_len as usize - libc::CMSG_LEN(0) as usize,
                             );
                             *last_group = Some(utils::parse_u32(&data[..4]).unwrap());
                         }


### PR DESCRIPTION
After upgrading to 0.3.0 my project would not compile against x86_64-unknown-linux-musl anymore:

<details>
  <summary>Compilation log</summary>

```rust
cargo build --target x86_64-unknown-linux-musl                                                                                                                         ⏱ 8s 🕑 13:07 ✖ 101
   Compiling netlink-socket2 v0.3.0
error[E0308]: mismatched types
   --> /Users/lochnair/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/netlink-socket2-0.3.0/src/multicast.rs:157:33
    |
157 |                 msg_controllen: control_buf.len(),
    |                                 ^^^^^^^^^^^^^^^^^ expected `u32`, found `usize`

error: cannot construct `msghdr` with struct literal syntax due to private fields
   --> /Users/lochnair/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/netlink-socket2-0.3.0/src/multicast.rs:151:30
    |
151 |             let mut msghdr = libc::msghdr {
    |                              ^^^^^^^^^^^^
    |
    = note: ...and other private fields `__pad1` and `__pad2` that were not provided

error[E0027]: pattern does not mention field `__pad1`
   --> /Users/lochnair/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/netlink-socket2-0.3.0/src/multicast.rs:176:25
    |
176 |                       let libc::cmsghdr {
    |  _________________________^
177 | |                         cmsg_len,
178 | |                         cmsg_level,
179 | |                         cmsg_type,
180 | |                     } = *cmsg_ptr;
    | |_____________________^ missing field `__pad1`
    |
help: include the missing field in the pattern
    |
179 -                         cmsg_type,
180 -                     } = *cmsg_ptr;
179 +                         cmsg_type, __pad1 } = *cmsg_ptr;
    |
help: if you don't care about this missing field, you can explicitly ignore it
    |
179 -                         cmsg_type,
180 -                     } = *cmsg_ptr;
179 +                         cmsg_type, __pad1: _ } = *cmsg_ptr;
    |
help: or always ignore missing fields here
    |
179 -                         cmsg_type,
180 -                     } = *cmsg_ptr;
179 +                         cmsg_type, .. } = *cmsg_ptr;
    |

error[E0308]: mismatched types
   --> /Users/lochnair/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/netlink-socket2-0.3.0/src/multicast.rs:186:44
    |
186 | ...                   cmsg_len - libc::CMSG_LEN(0) as usize,
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `u32`, found `usize`

error[E0277]: cannot subtract `usize` from `u32`
   --> /Users/lochnair/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/netlink-socket2-0.3.0/src/multicast.rs:186:42
    |
186 | ...                   cmsg_len - libc::CMSG_LEN(0) as usize,
    |                                ^ no implementation for `u32 - usize`
    |
    = help: the trait `Sub<usize>` is not implemented for `u32`
help: the following other types implement trait `Sub<Rhs>`
   --> /Volumes/Personal/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ops/arith.rs:227:1
    |
227 | sub_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f16 f32 f64 f128 }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    | |
    | `&u32` implements `Sub<u32>`
    | `&u32` implements `Sub`
    | `u32` implements `Sub<&u32>`
    | `u32` implements `Sub`
    = note: this error originates in the macro `forward_ref_binop` which comes from the expansion of the macro `sub_impl` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0308]: mismatched types
   --> /Users/lochnair/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/netlink-socket2-0.3.0/src/multicast.rs:186:33
    |
184 | ...                   let data = std::slice::from_raw_parts(
    |                                  -------------------------- arguments to this function are incorrect
185 | ...                       libc::CMSG_DATA(cmsg_ptr),
186 | ...                       cmsg_len - libc::CMSG_LEN(0) as usize,
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `u32`
    |
note: function defined here
   --> /Volumes/Personal/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/slice/raw.rs:124:21
    |
124 | pub const unsafe fn from_raw_parts<'a, T>(data: *const T, len: usize) -> &'a [T] {
    |                     ^^^^^^^^^^^^^^
help: you can convert a `u32` to a `usize` and panic if the converted value doesn't fit
    |
186 |                                 (cmsg_len - libc::CMSG_LEN(0) as usize).try_into().unwrap(),
    |                                 +                                     +++++++++++++++++++++

Some errors have detailed explanations: E0027, E0277, E0308.
For more information about an error, try `rustc --explain E0027`.
error: could not compile `netlink-socket2` (lib) due to 6 previous errors

```

</details>

I've tried to fix the type mismatch and avoid using struct literal syntax to create the msghdr so we don't touch the private fields.

Used a workflow to test on both Ubuntu and Alpine (through a container): https://github.com/Lochnair/netlink-bindings/actions/runs/24386804628

And at least as far as I can tell, it now runs successfully on both targets